### PR TITLE
Flying villager

### DIFF
--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/__main__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/__main__.mcfunction
@@ -51,7 +51,7 @@ title @a[scores={language=1},tag=has_egg] actionbar ["",{"text":"||","obfuscated
 
 execute as @e[type=minecraft:villager] at @s if entity @a[distance=..0.5] run effect give @s minecraft:invisibility 1 1 true
 
-execute as @e[type=minecraft:villager] at @s unless block ~ ~ ~ #scaffolding_rush:air unless block ~ ~ ~ minecraft:scaffolding run tp @s ~ ~0.1 ~
+execute as @e[type=minecraft:villager] at @s unless block ~ ~ ~ air unless block ~ ~ ~ minecraft:scaffolding run tp @s ~ ~0.1 ~
 
 execute if score GameEnd global matches 0 unless score DevelopementMode global matches 1 if score RemainingTeam global matches ..1 run function scaffolding_rush:game/finish
 

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/__main__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/__main__.mcfunction
@@ -51,7 +51,7 @@ title @a[scores={language=1},tag=has_egg] actionbar ["",{"text":"||","obfuscated
 
 execute as @e[type=minecraft:villager] at @s if entity @a[distance=..0.5] run effect give @s minecraft:invisibility 1 1 true
 
-execute as @e[type=minecraft:villager] at @s unless block ~ ~ ~ air unless block ~ ~ ~ minecraft:scaffolding run tp @s ~ ~0.1 ~
+execute as @e[type=minecraft:villager] at @s unless block ~ ~ ~ #scaffolding_rush:air unless block ~ ~ ~ minecraft:scaffolding run tp @s ~ ~0.1 ~
 
 execute if score GameEnd global matches 0 unless score DevelopementMode global matches 1 if score RemainingTeam global matches ..1 run function scaffolding_rush:game/finish
 

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/tags/blocks/air.json
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/tags/blocks/air.json
@@ -1,0 +1,6 @@
+{
+    "values": [
+        "minecraft:air",
+        "minecraft:cave_air"
+    ]
+}


### PR DESCRIPTION
Closes #33.
This PR resolve the issue with the flying villager.
The cause was that the command was trying to use a removed block tag.