### PR TITLE
fix: lobby reset not working when leaving world ingame

### DIFF
--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__init__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__init__.mcfunction
@@ -5,6 +5,7 @@ fill -90 0 -90 90 0 90 bedrock
 fill 1090 0 1090 910 0 910 bedrock
 
 forceload add 1100 1100 900 900
+forceload add 100 100 -100 -100
 
 #trigger controls
 # use "/scoreboard players set DevelopementMode global 1" in order to start the map solo


### PR DESCRIPTION
This issue was caused by the fact that the lobby chunks were not loaded.
Adding `forceload` for this area fixes the issue.