### PR TITLE
Scaffolding blocks arrows

### DIFF
--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__init__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__init__.mcfunction
@@ -39,6 +39,7 @@ scoreboard objectives add opt_interactible_lobby trigger
 scoreboard objectives add opt_volcano trigger
 scoreboard objectives add opt_volcano_summon_period trigger
 scoreboard objectives add opt_volcano_pop_period trigger
+scoreboard objectives add opt_scaff_stops_arrow trigger
 
 #internal values
 scoreboard objectives add timer dummy
@@ -88,6 +89,7 @@ execute unless score WBSize options matches 25..165 run scoreboard players set W
 execute unless score Volcano options matches 0.. run scoreboard players set Volcano options 0
 execute unless score VolcanoSummonPeriod options matches 0.. run scoreboard players set VolcanoSummonPeriod options 1200
 execute unless score VolcanoPopPeriod options matches 0.. run scoreboard players set VolcanoPopPeriod options 10
+execute unless score ScaffoldingStopsArrow options matches 0.. run scoreboard players set ScaffoldingStopsArrow options 0
 
 #advancement replenish
 advancement revoke @a from scaffolding_rush:replenish

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__main__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__main__.mcfunction
@@ -87,4 +87,3 @@ execute unless entity @a[tag=admin] if score Admin options matches 1 run functio
 
 # Scaffoldings blocks arrows
 execute as @e[type=arrow] at @s if score ScaffoldingStopsArrow options matches 1 if block ~ ~ ~ minecraft:scaffolding run kill @s
-execute as @e[type=arrow] at @s if score ScaffoldingStopsArrow options matches 1 if block ^ ^-1 ^ minecraft:scaffolding run kill @s

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__main__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__main__.mcfunction
@@ -85,3 +85,6 @@ execute as @e[type=villager,nbt=!{Age:0}] run function scaffolding_rush:clean_ki
 # Admin mode
 execute unless entity @a[tag=admin] if score Admin options matches 1 run function scaffolding_rush:options/admin
 
+# Scaffoldings blocks arrows
+execute as @e[type=arrow] at @s if score ScaffoldingStopsArrow options matches 1 if block ~ ~ ~ minecraft:scaffolding run kill @s
+execute as @e[type=arrow] at @s if score ScaffoldingStopsArrow options matches 1 if block ^ ^-1 ^ minecraft:scaffolding run kill @s

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/__main__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/__main__.mcfunction
@@ -25,3 +25,4 @@ execute as @a[scores={opt_interactible_lobby=1..}] run function scaffolding_rush
 execute as @a[scores={opt_volcano=1..}] run function scaffolding_rush:options/volcano
 execute as @a[scores={opt_volcano_summon_period=1..}] run function scaffolding_rush:options/volcano_summon_period
 execute as @a[scores={opt_volcano_pop_period=1..}] run function scaffolding_rush:options/volcano_pop_period
+execute as @a[scores={opt_scaff_stops_arrow=1..}] run function scaffolding_rush:options/scaff_stops_arrow

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/activate_all.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/activate_all.mcfunction
@@ -23,6 +23,7 @@ scoreboard players enable @s opt_interactible_lobby
 scoreboard players enable @s opt_volcano
 scoreboard players enable @s opt_volcano_summon_period
 scoreboard players enable @s opt_volcano_pop_period
+scoreboard players enable @s opt_scaff_stops_arrow
 
 
 scoreboard players enable @s Reset

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/disable_all.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/disable_all.mcfunction
@@ -23,6 +23,7 @@ scoreboard players reset @s opt_interactible_lobby
 scoreboard players reset @s opt_volcano
 scoreboard players reset @s opt_volcano_summon_period
 scoreboard players reset @s opt_volcano_pop_period
+scoreboard players reset @s opt_scaff_stops_arrow
 
 scoreboard players reset @s Reset
 scoreboard players reset @s StartGame

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/scaff_stops_arrow.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/scaff_stops_arrow.mcfunction
@@ -1,0 +1,13 @@
+
+execute store success score ScaffoldingStopsArrow options if score ScaffoldingStopsArrow options matches 0
+
+execute if score ScaffoldingStopsArrow options matches 0 run tellraw @a[scores={language=0}] ["",{"text":"[SR] ","color":"gold"},{"text":"Scaffoldings stops arrow has been ","color":"gray"},{"text":"deactivated","color":"red"}]
+execute unless score ScaffoldingStopsArrow options matches 0 run tellraw @a[scores={language=0}] ["",{"text":"[SR] ","color":"gold"},{"text":"Scaffoldings stops arrow has been ","color":"gray"},{"text":"activated","color":"green"}]
+
+execute if score ScaffoldingStopsArrow options matches 0 run tellraw @a[scores={language=1}] ["",{"text":"[SR] ","color":"gold"},{"text":"Flèches stoppées par les échafaudages a été ","color":"gray"},{"text":"désactivé","color":"red"}]
+execute unless score ScaffoldingStopsArrow options matches 0 run tellraw @a[scores={language=1}] ["",{"text":"[SR] ","color":"gold"},{"text":"Flèches stoppées par les échafaudages a été ","color":"gray"},{"text":"activé","color":"green"}]
+
+scoreboard players set @s opt_scaff_stops_arrow 0
+scoreboard players enable @s opt_scaff_stops_arrow
+
+function scaffolding_rush:options/refresh


### PR DESCRIPTION
This PR adds an option to make scaffolding destroy arrows in the same behaviour as any solid block.
To enable this behaviour, just type `/trigger opt_scaff_stops_arrow`.

This PR closes #14.