### PR TITLE
✨Volcano-event-ballistic-targeting

### DIFF
--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__init__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/__init__.mcfunction
@@ -35,6 +35,7 @@ scoreboard objectives add opt_interactible_lobby trigger
 scoreboard objectives add opt_volcano trigger
 scoreboard objectives add opt_volcano_summon_period trigger
 scoreboard objectives add opt_volcano_pop_period trigger
+scoreboard objectives add opt_volcano_target_rate trigger
 scoreboard objectives add opt_scaff_stops_arrow trigger
 
 #internal values
@@ -106,6 +107,7 @@ execute unless score WBSize options matches 25..165 run scoreboard players set W
 execute unless score Volcano options matches 0.. run scoreboard players set Volcano options 0
 execute unless score VolcanoSummonPeriod options matches 0.. run scoreboard players set VolcanoSummonPeriod options 1200
 execute unless score VolcanoPopPeriod options matches 0.. run scoreboard players set VolcanoPopPeriod options 10
+execute unless score VolcanoTargetRate options matches 0.. run scoreboard players set VolcanoTargetRate options 25
 execute unless score ScaffoldingStopsArrow options matches 0.. run scoreboard players set ScaffoldingStopsArrow options 0
 execute unless score FlagTakeOverSpawnInterval options matches 0.. run scoreboard players set FlagTakeOverSpawnInterval options 600
 #initialize options scores

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/random_initial_velocity.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/random_initial_velocity.mcfunction
@@ -1,0 +1,33 @@
+# This function gives to the source entity a random random initial motion vector
+
+# Generating random angle
+function glib.math:special/random
+scoreboard players operation @s glib.res0 %= 360 glib.const
+scoreboard players operation @s glib.var0 = @s glib.res0
+
+# Getting max speed over X and Z
+function glib.math:trig/cos
+scoreboard players operation #VolcanoXmax glib = @s glib.res0
+function glib.math:trig/sin
+scoreboard players operation #VolcanoZmax glib = @s glib.res0
+
+# Generating random speed over X and Z
+function glib.math:special/random
+execute if score @s glib.res0 matches ..-1 run tag @s add reverse_motion
+scoreboard players operation @s glib.res0 %= #VolcanoXmax glib
+scoreboard players operation @s[tag=reverse_motion] glib.res0 *= -1 const
+scoreboard players operation @s glib.vectorX = @s glib.res0
+tag @s remove reverse_motion
+
+function glib.math:special/random
+execute if score @s glib.res0 matches ..-1 run tag @s add reverse_motion
+scoreboard players operation @s glib.res0 %= #VolcanoZmax glib
+scoreboard players operation @s[tag=reverse_motion] glib.res0 *= -1 const
+scoreboard players operation @s glib.vectorZ = @s glib.res0
+tag @s remove reverse_motion
+
+# Y motion
+function scaffolding_rush:lib/random
+scoreboard players operation @s glib.res0 %= 500 glib.const
+scoreboard players add @s glib.res0 500
+scoreboard players operation @s glib.vectorY = @s glib.res0

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/random_walk.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/random_walk.mcfunction
@@ -1,0 +1,22 @@
+# Random walk on X
+function glib.math:special/random
+scoreboard players operation @s glib.res0 %= 100 glib.const
+execute at @s if score @s glib.res0 matches ..49 positioned ~1 ~ ~ if block ~ ~ ~ scaffolding align xyz run tp @s ~0.5 ~0.5 ~0.5
+execute at @s if score @s glib.res0 matches 50.. positioned ~-1 ~ ~ if block ~ ~ ~ scaffolding align xyz run tp @s ~0.5 ~0.5 ~0.5
+
+# Random walk on Z
+function glib.math:special/random
+scoreboard players operation @s glib.res0 %= 100 glib.const
+execute at @s if score @s glib.res0 matches ..49 positioned ~ ~ ~1 if block ~ ~ ~ scaffolding align xyz run tp @s ~0.5 ~0.5 ~0.5
+execute at @s if score @s glib.res0 matches 50.. positioned ~ ~ ~-1 if block ~ ~ ~ scaffolding align xyz run tp @s ~0.5 ~0.5 ~0.5
+
+# Random walk on Y
+function glib.math:special/random
+scoreboard players operation @s glib.res0 %= 100 glib.const
+execute at @s if score @s glib.res0 matches ..24 positioned ~ ~1 ~ if block ~ ~ ~ scaffolding align xyz run tp @s ~0.5 ~0.5 ~0.5
+execute at @s if score @s glib.res0 matches 25.. positioned ~ ~-1 ~ if block ~ ~ ~ scaffolding align xyz run tp @s ~0.5 ~0.5 ~0.5
+
+# particle end_rod ~ ~1 ~ 0 0 0 0 1 force
+
+scoreboard players remove #RandoWalk global 1
+execute at @s if score #RandoWalk global matches 1.. run function scaffolding_rush:game/volcano/projection/random_walk

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
@@ -1,48 +1,10 @@
 summon armor_stand ~ ~ ~ {NoGravity:1,Invisible:1,Tags:["Volcano","VolcanoPop","VolcanoPopNew"],ArmorItems:[{},{},{},{id:"minecraft:magma_block",Count:1b}]}
 
-# execute as @e[tag=VolcanoPopNew] run tellraw @a [{"text":"---"}]
-
-# Generating random angle
 execute as @e[tag=VolcanoPopNew] run function glib.math:special/random
-execute as @e[tag=VolcanoPopNew] run scoreboard players operation @s glib.res0 %= 360 glib.const
-execute as @e[tag=VolcanoPopNew] run scoreboard players operation @s glib.var0 = @s glib.res0
 
-# Getting max speed over X and Z
-execute as @e[tag=VolcanoPopNew] run function glib.math:trig/cos
-execute as @e[tag=VolcanoPopNew] run scoreboard players operation #VolcanoXmax glib = @s glib.res0
-# execute as @e[tag=VolcanoPopNew] run scoreboard players operation #VolcanoXmax glib *= 3 glib.const
-execute as @e[tag=VolcanoPopNew] run function glib.math:trig/sin
-execute as @e[tag=VolcanoPopNew] run scoreboard players operation #VolcanoZmax glib = @s glib.res0
-# execute as @e[tag=VolcanoPopNew] run scoreboard players operation #VolcanoZmax glib *= 3 glib.const
-
-# Generating random speed over X and Z
-execute as @e[tag=VolcanoPopNew] run function glib.math:special/random
-execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches ..-1 run tag @s add reverse_motion
-execute as @e[tag=VolcanoPopNew] run scoreboard players operation @s glib.res0 %= #VolcanoXmax glib
-scoreboard players operation @e[tag=VolcanoPopNew,tag=reverse_motion] glib.res0 *= -1 const
-execute as @e[tag=VolcanoPopNew] run scoreboard players operation @s glib.vectorX = @s glib.res0
-# execute as @e[tag=VolcanoPopNew] store result entity @s Motion[0] double 0.001 run scoreboard players get @s glib.res0
-tag @e[tag=VolcanoPopNew] remove reverse_motion
-# execute as @e[tag=VolcanoPopNew] run tellraw @a ["",{"text":"Vector X: "},{"score":{"name":"@s","objective":"glib.res0"}}]
-
-execute as @e[tag=VolcanoPopNew] run function glib.math:special/random
-execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches ..-1 run tag @s add reverse_motion
-execute as @e[tag=VolcanoPopNew] run scoreboard players operation @s glib.res0 %= #VolcanoZmax glib
-scoreboard players operation @e[tag=VolcanoPopNew,tag=reverse_motion] glib.res0 *= -1 const
-execute as @e[tag=VolcanoPopNew] run scoreboard players operation @s glib.vectorZ = @s glib.res0
-# execute as @e[tag=VolcanoPopNew] store result entity @s Motion[2] double 0.001 run scoreboard players get @s glib.res0
-tag @e[tag=VolcanoPopNew] remove reverse_motion
-# execute as @e[tag=VolcanoPopNew] run tellraw @a ["",{"text":"Vector Z: "},{"score":{"name":"@s","objective":"glib.res0"}}]
-
-# Y motion
-execute as @e[tag=VolcanoPopNew] run function scaffolding_rush:lib/random
-scoreboard players operation @e[tag=VolcanoPopNew] glib.res0 %= 500 glib.const
-scoreboard players add @e[tag=VolcanoPopNew] glib.res0 500
-execute as @e[tag=VolcanoPopNew] run scoreboard players operation @s glib.vectorY = @s glib.res0
-# execute as @e[tag=VolcanoPopNew] store result entity @s Motion[1] double 0.001 run scoreboard players get @s glib.res0
-# execute as @e[tag=VolcanoPopNew] run tellraw @a ["",{"text":"Vector Y: "},{"score":{"name":"@s","objective":"glib.res0"}}]
-
-# execute as @e[tag=VolcanoPopNew] run tellraw @a ["",{"text":"Summon > X: ","color":"gray"},{"score":{"name":"@s","objective":"glib.vectorX"},"color":"gold"},{"text":" Y: ","color":"gray"},{"score":{"name":"@s","objective":"glib.vectorY"},"color":"gold"},{"text":" Z: ","color":"gray"},{"score":{"name":"@s","objective":"glib.vectorZ"},"color":"gold"}]
+scoreboard players operation @e[tag=VolcanoPopNew] glib.res0 %= 25 glib.const
+execute as @e[tag=VolcanoPopNew] unless score @s glib.res0 matches 0 run function scaffolding_rush:game/volcano/projection/random_initial_velocity
+execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches 0 run function scaffolding_rush:game/volcano/projection/target_random_player
 
 
 tag @e remove VolcanoPopNew

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
@@ -2,9 +2,14 @@ summon armor_stand ~ ~ ~ {NoGravity:1,Invisible:1,Tags:["Volcano","VolcanoPop","
 
 execute as @e[tag=VolcanoPopNew] run function glib.math:special/random
 
+
+execute as @e[tag=VolcanoPopNew] run function scaffolding_rush:game/volcano/projection/random_initial_velocity
+
 scoreboard players operation @e[tag=VolcanoPopNew] glib.res0 %= 25 glib.const
-execute as @e[tag=VolcanoPopNew] unless score @s glib.res0 matches 0 run function scaffolding_rush:game/volcano/projection/random_initial_velocity
-execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches 0 run function scaffolding_rush:game/volcano/projection/target_random_player
+# execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run effect give @s glowing 999 1 true
+execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run function scaffolding_rush:game/volcano/projection/target_random_player
 
 
 tag @e remove VolcanoPopNew
+
+# ,tag=!TeamEliminated

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
@@ -5,7 +5,7 @@ execute as @e[tag=VolcanoPopNew] run function glib.math:special/random
 
 execute as @e[tag=VolcanoPopNew] run function scaffolding_rush:game/volcano/projection/random_initial_velocity
 
-scoreboard players operation @e[tag=VolcanoPopNew] glib.res0 %= 25 glib.const
+scoreboard players operation @e[tag=VolcanoPopNew] glib.res0 %= VolcanoTargetRate options
 # execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run effect give @s glowing 999 1 true
 execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run function scaffolding_rush:game/volcano/projection/target_random_player
 

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/target_random_player.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/target_random_player.mcfunction
@@ -4,13 +4,25 @@
 # Discussion and demo here: https://github.com/Gunivers/Blazing-Scaffolding/issues/90
 
 # Select the random player
-tag @r[distance=..30] add VolcanoTarget
+kill @e[tag=VolcanoTarget]
+execute at @a[limit=1,sort=random,distance=..50,tag=InGame,gamemode=adventure] run summon marker ~ ~ ~ {Tags:["VolcanoTarget"]}
+
+execute as @e[tag=VolcanoTarget] at @s unless block ~ ~ ~ scaffolding unless block ~ ~-1 ~ scaffolding run tag @s add VolcanoAbortTarget
+
+execute as @e[tag=VolcanoTarget,tag=VolcanoAbortTarget] at @s run tp @s ~ ~5 ~
+
+scoreboard players set #RandoWalk global 25
+execute as @e[tag=VolcanoTarget] at @s run function scaffolding_rush:game/volcano/projection/random_walk
+
+execute at @e[tag=VolcanoTarget,tag=!VolcanoAbortTarget] run particle lava ~ ~0.55 ~ 0.5 0.5 0.5 0 50 force
+execute at @e[tag=VolcanoTarget,tag=!VolcanoAbortTarget] run playsound minecraft:item.bucket.fill_lava master @a[distance=..30] ~ ~ ~ 2 2 1
+#  unless entity @a[tag=InGame,gamemode=adventure,distance=..2]
 
 # Final position rf in miliblock
-execute as @p[tag=VolcanoTarget] at @s run function glib.location:get
-scoreboard players operation #rf_x global = @p[tag=VolcanoTarget] glib.locX
-scoreboard players operation #rf_y global = @p[tag=VolcanoTarget] glib.locY
-scoreboard players operation #rf_z global = @p[tag=VolcanoTarget] glib.locZ
+execute as @e[tag=VolcanoTarget] at @s run function glib.location:get
+scoreboard players operation #rf_x global = @e[tag=VolcanoTarget] glib.locX
+scoreboard players operation #rf_y global = @e[tag=VolcanoTarget] glib.locY
+scoreboard players operation #rf_z global = @e[tag=VolcanoTarget] glib.locZ
 scoreboard players operation #rf_x global *= 1000 glib.const
 scoreboard players operation #rf_y global *= 1000 glib.const
 scoreboard players operation #rf_z global *= 1000 glib.const
@@ -24,10 +36,10 @@ scoreboard players operation #ri_x global *= 1000 glib.const
 scoreboard players operation #ri_y global *= 1000 glib.const
 scoreboard players operation #ri_z global *= 1000 glib.const
 
-# Time to reach the player in ticks (default: 3-5s -> 60-100 ticks)
+# Time to reach the player in ticks (default: 2-3s -> 40-60 ticks)
 function glib.math:special/random
-scoreboard players operation @s glib.res0 %= 40 glib.const
-scoreboard players set #T global 60
+scoreboard players operation @s glib.res0 %= 20 glib.const
+scoreboard players set #T global 40
 scoreboard players operation #T global += @s glib.res0
 
 # Gravity in miliblock/tick² (default: 0.98m/s² -> 24 miliblock/tick²)
@@ -52,3 +64,5 @@ scoreboard players operation #scnd_term global /= 2 glib.const
 
 scoreboard players operation @s glib.vectorY -= #scnd_term global
 
+# Clear
+kill @e[tag=VolcanoTarget]

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/target_random_player.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/target_random_player.mcfunction
@@ -1,0 +1,54 @@
+# This function select a random nearby player and return a vector that will reach him via a ballistic trajectory
+
+# It follow the formula : v = (r_f - r_i) / T - g * T / 2
+# Discussion and demo here: https://github.com/Gunivers/Blazing-Scaffolding/issues/90
+
+# Select the random player
+tag @r[distance=..30] add VolcanoTarget
+
+# Final position rf in miliblock
+execute as @p[tag=VolcanoTarget] at @s run function glib.location:get
+scoreboard players operation #rf_x global = @p[tag=VolcanoTarget] glib.locX
+scoreboard players operation #rf_y global = @p[tag=VolcanoTarget] glib.locY
+scoreboard players operation #rf_z global = @p[tag=VolcanoTarget] glib.locZ
+scoreboard players operation #rf_x global *= 1000 glib.const
+scoreboard players operation #rf_y global *= 1000 glib.const
+scoreboard players operation #rf_z global *= 1000 glib.const
+
+# Initial position ri in miliblock
+function glib.location:get
+scoreboard players operation #ri_x global = @s glib.locX
+scoreboard players operation #ri_y global = @s glib.locY
+scoreboard players operation #ri_z global = @s glib.locZ
+scoreboard players operation #ri_x global *= 1000 glib.const
+scoreboard players operation #ri_y global *= 1000 glib.const
+scoreboard players operation #ri_z global *= 1000 glib.const
+
+# Time to reach the player in ticks (default: 3-5s -> 60-100 ticks)
+function glib.math:special/random
+scoreboard players operation @s glib.res0 %= 40 glib.const
+scoreboard players set #T global 60
+scoreboard players operation #T global += @s glib.res0
+
+# Gravity in miliblock/tick² (default: 0.98m/s² -> 24 miliblock/tick²)
+scoreboard players set #g global -24
+
+# Apply formula
+scoreboard players operation @s glib.vectorX = #rf_x global
+scoreboard players operation @s glib.vectorX -= #ri_x global
+scoreboard players operation @s glib.vectorX /= #T global
+
+scoreboard players operation @s glib.vectorY = #rf_y global
+scoreboard players operation @s glib.vectorY -= #ri_y global
+scoreboard players operation @s glib.vectorY /= #T global
+
+scoreboard players operation @s glib.vectorZ = #rf_z global
+scoreboard players operation @s glib.vectorZ -= #ri_z global
+scoreboard players operation @s glib.vectorZ /= #T global
+
+scoreboard players operation #scnd_term global = #g global
+scoreboard players operation #scnd_term global *= #T global
+scoreboard players operation #scnd_term global /= 2 glib.const
+
+scoreboard players operation @s glib.vectorY -= #scnd_term global
+

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/__main__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/__main__.mcfunction
@@ -24,6 +24,7 @@ execute as @a[scores={opt_interactible_lobby=1..}] run function scaffolding_rush
 execute as @a[scores={opt_volcano=1..}] run function scaffolding_rush:options/volcano
 execute as @a[scores={opt_volcano_summon_period=1..}] run function scaffolding_rush:options/volcano_summon_period
 execute as @a[scores={opt_volcano_pop_period=1..}] run function scaffolding_rush:options/volcano_pop_period
+execute as @a[scores={opt_volcano_target_rate=1..}] run function scaffolding_rush:options/volcano_target_rate
 execute as @a[scores={opt_scaff_stops_arrow=1..}] run function scaffolding_rush:options/scaff_stops_arrow
 execute as @a[scores={opt_time_limit=1..}] run function scaffolding_rush:options/time_limit
 execute as @a[scores={opt_score_limit=1..}] run function scaffolding_rush:options/score_limit

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/activate_all.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/activate_all.mcfunction
@@ -27,6 +27,7 @@ scoreboard players enable @s opt_interactible_lobby
 scoreboard players enable @s opt_volcano
 scoreboard players enable @s opt_volcano_summon_period
 scoreboard players enable @s opt_volcano_pop_period
+scoreboard players enable @s opt_volcano_target_rate
 scoreboard players enable @s opt_scaff_stops_arrow
 
 scoreboard players enable @s Reset

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/disable_all.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/disable_all.mcfunction
@@ -28,6 +28,7 @@ scoreboard players reset @s opt_interactible_lobby
 scoreboard players reset @s opt_volcano
 scoreboard players reset @s opt_volcano_summon_period
 scoreboard players reset @s opt_volcano_pop_period
+scoreboard players reset @s opt_volcano_target_rate
 scoreboard players reset @s opt_scaff_stops_arrow
 
 scoreboard players reset @s Reset

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/volcano_target_rate.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/options/volcano_target_rate.mcfunction
@@ -1,0 +1,10 @@
+
+scoreboard players operation VolcanoTargetRate options = @s opt_volcano_target_rate
+
+tellraw @a[scores={language=0}] ["",{"text":"[SR] ","color":"gold"},{"text":"The lava pop target rate has been set to once every ","color":"gray"},{"score":{"name":"VolcanoTargetRate","objective":"options"},"color":"gold"},{"text":" pops","color":"gray"}]
+tellraw @a[scores={language=1}] ["",{"text":"[SR] ","color":"gold"},{"text":"Le taux de ciblage des gerbes de lave a été défini à une toutes les ","color":"gray"},{"score":{"name":"VolcanoTargetRate","objective":"options"},"color":"gold"},{"text":" gerbes","color":"gray"}]
+
+scoreboard players set @s opt_volcano_target_rate 0
+scoreboard players enable @s opt_volcano_target_rate
+
+function scaffolding_rush:options/refresh


### PR DESCRIPTION
Cette PR ajoute la probabilité d'une gerbe d'un voclan puisse être verrouillé sur la position d'un joueur, de sorte à augmenter l'impact des gerbes de lave sur le déroulement des parties

ToDoList:
- [x] Selection aléatoire entre trajectoire aléatoire et ciblée
- [x] Calcul de la vitesse initiale
- [x] Temps du tir aléatoire (le projectile met entre 3 et 5 secondes à atteindre sa cible)
- [x] Ciblage des échafaudages (cibler une entité partant du joueur et se déplacement aléatoirement dans les échaffaudage afin de cibler ces derniers plutôt quel es joueurs directement

> **Note**
> Fait suite à l'issue #90