### PR TITLE
Volcano pop security

### DIFF
--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/__main__.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/__main__.mcfunction
@@ -3,16 +3,16 @@ execute if score VolcanoSummonTimer timer >= VolcanoSummonPeriod options run fun
 execute if score VolcanoSummonTimer timer >= VolcanoSummonPeriod options run scoreboard players set VolcanoSummonTimer timer 0
 scoreboard players add VolcanoSummonTimer timer 1
 
-execute if score VolcanoPopTimer timer >= VolcanoPopPeriod options at @e[tag=VolcanoBase] positioned ~ ~3 ~ run function scaffolding_rush:game/volcano/projection/summon
+execute if score VolcanoPopTimer timer >= VolcanoPopPeriod options at @e[type=marker,tag=VolcanoBase] positioned ~ ~3 ~ run function scaffolding_rush:game/volcano/projection/summon
 execute if score VolcanoPopTimer timer >= VolcanoPopPeriod options run scoreboard players set VolcanoPopTimer timer 0
 scoreboard players add VolcanoPopTimer timer 1
 
-execute if entity @e[tag=VolcanoPop] run function scaffolding_rush:game/volcano/projection/motion
+execute if entity @e[type=marker,tag=VolcanoPop] run function scaffolding_rush:game/volcano/projection/motion
 
-execute at @e[tag=VolcanoBase,scores={glib.lifetime=4}] run place template scaffolding_rush:volcano ~-7 ~-4 ~-7
-execute at @e[tag=VolcanoBase,scores={glib.lifetime=8}] run place template scaffolding_rush:volcano ~-7 ~-3 ~-7
-execute at @e[tag=VolcanoBase,scores={glib.lifetime=12}] run place template scaffolding_rush:volcano ~-7 ~-2 ~-7
-execute at @e[tag=VolcanoBase,scores={glib.lifetime=16}] run place template scaffolding_rush:volcano ~-7 ~-1 ~-7
-execute at @e[tag=VolcanoBase,scores={glib.lifetime=20}] run place template scaffolding_rush:volcano ~-7 ~ ~-7
+execute at @e[type=marker,tag=VolcanoBase,scores={glib.lifetime=4}] run place template scaffolding_rush:volcano ~-7 ~-4 ~-7
+execute at @e[type=marker,tag=VolcanoBase,scores={glib.lifetime=8}] run place template scaffolding_rush:volcano ~-7 ~-3 ~-7
+execute at @e[type=marker,tag=VolcanoBase,scores={glib.lifetime=12}] run place template scaffolding_rush:volcano ~-7 ~-2 ~-7
+execute at @e[type=marker,tag=VolcanoBase,scores={glib.lifetime=16}] run place template scaffolding_rush:volcano ~-7 ~-1 ~-7
+execute at @e[type=marker,tag=VolcanoBase,scores={glib.lifetime=20}] run place template scaffolding_rush:volcano ~-7 ~ ~-7
 
-execute as @e[tag=VolcanoBase] at @s if block 1000 ~5 1000 magma_block run kill @s
+execute as @e[type=marker,tag=VolcanoBase] at @s if block 1000 ~5 1000 magma_block run kill @s

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/motion.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/motion.mcfunction
@@ -1,18 +1,18 @@
-execute as @e[tag=VolcanoPop] at @s run function glib.move:by_vector
-scoreboard players remove @e[tag=VolcanoPop] glib.vectorY 25
+execute as @e[type=armor_stand,tag=VolcanoPop] at @s run function glib.move:by_vector
+scoreboard players remove @e[type=armor_stand,tag=VolcanoPop] glib.vectorY 25
 
-execute as @e[tag=VolcanoPop] at @s run tp @s ~ ~ ~ ~5 ~
+execute as @e[type=armor_stand,tag=VolcanoPop] at @s run tp @s ~ ~ ~ ~5 ~
 
-execute as @e[tag=VolcanoPop] at @s run particle large_smoke ~ ~1.5 ~ 0.3 0.3 0.3 0 1 force
-execute as @e[tag=VolcanoPop] at @s run particle flame ~ ~1.5 ~ 0.3 0.3 0.3 0.1 1 force
+execute as @e[type=armor_stand,tag=VolcanoPop] at @s run particle large_smoke ~ ~1.5 ~ 0.3 0.3 0.3 0 1 force
+execute as @e[type=armor_stand,tag=VolcanoPop] at @s run particle flame ~ ~1.5 ~ 0.3 0.3 0.3 0.1 1 force
 
 # Set live to 10s and change collision type after 5 ticks
-scoreboard players set @e[tag=VolcanoPop,scores={glib.lifetime=0..}] glib.lifetime -200
-scoreboard players set @e[tag=VolcanoPop,scores={glib.vectorY=..-1}] glib.collision 3
-scoreboard players set @s[tag=VolcanoPop,scores={glib.vectorY=..-1}] glib.precision 1000
+scoreboard players set @e[type=armor_stand,tag=VolcanoPop,scores={glib.lifetime=0..}] glib.lifetime -200
+scoreboard players set @e[type=armor_stand,tag=VolcanoPop,scores={glib.vectorY=..-1}] glib.collision 3
+scoreboard players set @s[type=armor_stand,tag=VolcanoPop,scores={glib.vectorY=..-1}] glib.precision 1000
 
-execute as @e[tag=VolcanoPop,tag=Impact] at @s run playsound minecraft:entity.generic.explode master @a[distance=..30] ~ ~ ~ 2 1 1
-execute as @e[tag=VolcanoPop,tag=Impact] at @s run particle explosion_emitter ~ ~1.7 ~ 0 0 0 0 1 force
+execute as @e[type=armor_stand,tag=VolcanoPop,tag=Impact] at @s run playsound minecraft:entity.generic.explode master @a[distance=..30] ~ ~ ~ 2 1 1
+execute as @e[type=armor_stand,tag=VolcanoPop,tag=Impact] at @s run particle explosion_emitter ~ ~1.7 ~ 0 0 0 0 1 force
 
-execute as @e[tag=VolcanoPop,tag=Impact] at @s run fill ~-2 ~-2 ~-2 ~2 ~2 ~2 air replace #scaffolding_rush:scaffolding
-kill @e[tag=VolcanoPop,tag=Impact]
+execute as @e[type=armor_stand,tag=VolcanoPop,tag=Impact] at @s run fill ~-2 ~-2 ~-2 ~2 ~2 ~2 air replace #scaffolding_rush:scaffolding
+kill @e[type=armor_stand,tag=VolcanoPop,tag=Impact]

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/motion.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/motion.mcfunction
@@ -1,8 +1,6 @@
 execute as @e[type=marker,tag=VolcanoPop] at @s run function glib.move:by_vector
 scoreboard players remove @e[type=marker,tag=VolcanoPop] glib.vectorY 25
 
-execute as @e[type=marker,tag=VolcanoPop] at @s run tp @s ~ ~ ~ ~5 ~
-
 execute as @e[type=marker,tag=VolcanoPop] at @s run particle large_smoke ~ ~1.5 ~ 0.1 0.1 0.1 0.1 1 force
 execute as @e[type=marker,tag=VolcanoPop] at @s run particle flame ~ ~1.5 ~ 0.1 0.1 0.1 0.1 3 force
 # execute as @e[type=armor_stand,tag=VolcanoPop] at @s run particle lava ~ ~1.5 ~ 0.1 0.1 0.1 0.1 1 force

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/motion.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/motion.mcfunction
@@ -1,18 +1,30 @@
-execute as @e[type=armor_stand,tag=VolcanoPop] at @s run function glib.move:by_vector
-scoreboard players remove @e[type=armor_stand,tag=VolcanoPop] glib.vectorY 25
+execute as @e[type=marker,tag=VolcanoPop] at @s run function glib.move:by_vector
+scoreboard players remove @e[type=marker,tag=VolcanoPop] glib.vectorY 25
 
-execute as @e[type=armor_stand,tag=VolcanoPop] at @s run tp @s ~ ~ ~ ~5 ~
+execute as @e[type=marker,tag=VolcanoPop] at @s run tp @s ~ ~ ~ ~5 ~
 
-execute as @e[type=armor_stand,tag=VolcanoPop] at @s run particle large_smoke ~ ~1.5 ~ 0.3 0.3 0.3 0 1 force
-execute as @e[type=armor_stand,tag=VolcanoPop] at @s run particle flame ~ ~1.5 ~ 0.3 0.3 0.3 0.1 1 force
+execute as @e[type=marker,tag=VolcanoPop] at @s run particle large_smoke ~ ~1.5 ~ 0.1 0.1 0.1 0.1 1 force
+execute as @e[type=marker,tag=VolcanoPop] at @s run particle flame ~ ~1.5 ~ 0.1 0.1 0.1 0.1 3 force
+# execute as @e[type=armor_stand,tag=VolcanoPop] at @s run particle lava ~ ~1.5 ~ 0.1 0.1 0.1 0.1 1 force
 
-# Set live to 10s and change collision type after 5 ticks
-scoreboard players set @e[type=armor_stand,tag=VolcanoPop,scores={glib.lifetime=0..}] glib.lifetime -200
-scoreboard players set @e[type=armor_stand,tag=VolcanoPop,scores={glib.vectorY=..-1}] glib.collision 3
-scoreboard players set @s[type=armor_stand,tag=VolcanoPop,scores={glib.vectorY=..-1}] glib.precision 1000
+# Default behavior: no collision
+scoreboard players set @e[type=marker,tag=VolcanoPop] glib.collision 0
+# When the lava pop is in it's ascending phase, it collide only if there is a player in a 15 blocks radius
+execute as @e[type=marker,tag=VolcanoPop,scores={glib.vectorY=1..}] at @s if entity @a[distance=..15] run scoreboard players set @s glib.collision 3
+# When the lava pop is in it's descending phase, it collide only if there is a player in a 50 blocks radius
+execute as @e[type=marker,tag=VolcanoPop,scores={glib.vectorY=..-1}] at @s if entity @a[distance=..50] run scoreboard players set @s glib.collision 3
 
-execute as @e[type=armor_stand,tag=VolcanoPop,tag=Impact] at @s run playsound minecraft:entity.generic.explode master @a[distance=..30] ~ ~ ~ 2 1 1
-execute as @e[type=armor_stand,tag=VolcanoPop,tag=Impact] at @s run particle explosion_emitter ~ ~1.7 ~ 0 0 0 0 1 force
+# If no collision, no need to have an accurate precision
+scoreboard players set @e[type=marker,tag=VolcanoPop,scores={glib.collision=0}] glib.precision 1000
+# If collision is enable, we need to have a partially good precision (half a block)
+scoreboard players set @e[type=marker,tag=VolcanoPop,scores={glib.collision=3}] glib.precision 500
 
-execute as @e[type=armor_stand,tag=VolcanoPop,tag=Impact] at @s run fill ~-2 ~-2 ~-2 ~2 ~2 ~2 air replace #scaffolding_rush:scaffolding
-kill @e[type=armor_stand,tag=VolcanoPop,tag=Impact]
+# If no collision but the pop goes in the lava
+execute as @e[type=marker,tag=VolcanoPop,scores={glib.collision=0,glib.lifetime=-90..}] at @s if block ~ ~ ~ magma_block run tag @s add Impact
+
+# Impact affect
+execute as @e[type=marker,tag=VolcanoPop,tag=Impact] at @s run playsound minecraft:entity.generic.explode master @a[distance=..30] ~ ~ ~ 2 1 1
+execute as @e[type=marker,tag=VolcanoPop,tag=Impact] at @s run particle explosion_emitter ~ ~1.7 ~ 0 0 0 0 1 force
+
+execute as @e[type=marker,tag=VolcanoPop,tag=Impact] at @s run fill ~-2 ~-2 ~-2 ~2 ~2 ~2 air replace #scaffolding_rush:scaffolding
+kill @e[type=marker,tag=VolcanoPop,tag=Impact]

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
@@ -1,16 +1,22 @@
-summon armor_stand ~ ~ ~ {NoGravity:1,Invisible:1,Tags:["Volcano","VolcanoPop","VolcanoPopNew"],ArmorItems:[{},{},{},{id:"minecraft:magma_block",Count:1b}]}
+scoreboard players set #VolcanoPopNumber global 0
+execute as @e[type=armor_stand,tag=VolcanoPop] run scoreboard players add #VolcanoPopNumber global 1
 
-execute as @e[tag=VolcanoPopNew] run function glib.math:special/random
+execute if score #VolcanoPopNumber global matches 0..100 run summon armor_stand ~ ~ ~ {NoGravity:1,Invisible:1,Tags:["Volcano","VolcanoPop","VolcanoPopNew"],ArmorItems:[{},{},{},{id:"minecraft:magma_block",Count:1b}]}
+# summon block_display ~ ~ ~ {block_state:{Name:"minecraft:magma_block"},Tags:["Volcano","VolcanoPop","VolcanoPopNew"]}
+
+scoreboard players set @e[type=armor_stand,tag=VolcanoPopNew] glib.lifetime -200
+
+execute as @e[type=armor_stand,tag=VolcanoPopNew] run function glib.math:special/random
 
 
-execute as @e[tag=VolcanoPopNew] run function scaffolding_rush:game/volcano/projection/random_initial_velocity
+execute as @e[type=armor_stand,tag=VolcanoPopNew] run function scaffolding_rush:game/volcano/projection/random_initial_velocity
 
-scoreboard players operation @e[tag=VolcanoPopNew] glib.res0 %= VolcanoTargetRate options
+scoreboard players operation @e[type=armor_stand,tag=VolcanoPopNew] glib.res0 %= VolcanoTargetRate options
 # execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run effect give @s glowing 999 1 true
-execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run function scaffolding_rush:game/volcano/projection/target_random_player
+execute as @e[type=armor_stand,tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run function scaffolding_rush:game/volcano/projection/target_random_player
 
-scoreboard players set @e[tag=VolcanoPopNew] glib.collision 0
-scoreboard players set @e[tag=VolcanoPopNew] glib.precision 1000
+scoreboard players set @e[type=armor_stand,tag=VolcanoPopNew] glib.collision 0
+scoreboard players set @e[type=armor_stand,tag=VolcanoPopNew] glib.precision 1000
 
 tag @e remove VolcanoPopNew
 

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/summon.mcfunction
@@ -1,22 +1,23 @@
 scoreboard players set #VolcanoPopNumber global 0
-execute as @e[type=armor_stand,tag=VolcanoPop] run scoreboard players add #VolcanoPopNumber global 1
+execute as @e[type=marker,tag=VolcanoPop] run scoreboard players add #VolcanoPopNumber global 1
 
-execute if score #VolcanoPopNumber global matches 0..100 run summon armor_stand ~ ~ ~ {NoGravity:1,Invisible:1,Tags:["Volcano","VolcanoPop","VolcanoPopNew"],ArmorItems:[{},{},{},{id:"minecraft:magma_block",Count:1b}]}
+execute if score #VolcanoPopNumber global matches 0..50 run summon marker ~ ~ ~ {Tags:["Volcano","VolcanoPop","VolcanoPopNew"]}
+# 
 # summon block_display ~ ~ ~ {block_state:{Name:"minecraft:magma_block"},Tags:["Volcano","VolcanoPop","VolcanoPopNew"]}
 
-scoreboard players set @e[type=armor_stand,tag=VolcanoPopNew] glib.lifetime -200
+scoreboard players set @e[type=marker,tag=VolcanoPopNew] glib.lifetime -100
 
-execute as @e[type=armor_stand,tag=VolcanoPopNew] run function glib.math:special/random
+execute as @e[type=marker,tag=VolcanoPopNew] run function glib.math:special/random
 
 
-execute as @e[type=armor_stand,tag=VolcanoPopNew] run function scaffolding_rush:game/volcano/projection/random_initial_velocity
+execute as @e[type=marker,tag=VolcanoPopNew] run function scaffolding_rush:game/volcano/projection/random_initial_velocity
 
-scoreboard players operation @e[type=armor_stand,tag=VolcanoPopNew] glib.res0 %= VolcanoTargetRate options
+scoreboard players operation @e[type=marker,tag=VolcanoPopNew] glib.res0 %= VolcanoTargetRate options
 # execute as @e[tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run effect give @s glowing 999 1 true
-execute as @e[type=armor_stand,tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run function scaffolding_rush:game/volcano/projection/target_random_player
+execute as @e[type=marker,tag=VolcanoPopNew] if score @s glib.res0 matches 0 if entity @a[distance=..50,tag=InGame,gamemode=adventure] run function scaffolding_rush:game/volcano/projection/target_random_player
 
-scoreboard players set @e[type=armor_stand,tag=VolcanoPopNew] glib.collision 0
-scoreboard players set @e[type=armor_stand,tag=VolcanoPopNew] glib.precision 1000
+scoreboard players set @e[type=marker,tag=VolcanoPopNew] glib.collision 0
+scoreboard players set @e[type=marker,tag=VolcanoPopNew] glib.precision 1000
 
 tag @e remove VolcanoPopNew
 

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/target_random_player.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/projection/target_random_player.mcfunction
@@ -4,25 +4,25 @@
 # Discussion and demo here: https://github.com/Gunivers/Blazing-Scaffolding/issues/90
 
 # Select the random player
-kill @e[tag=VolcanoTarget]
+kill @e[type=marker,tag=VolcanoTarget]
 execute at @a[limit=1,sort=random,distance=..50,tag=InGame,gamemode=adventure] run summon marker ~ ~ ~ {Tags:["VolcanoTarget"]}
 
-execute as @e[tag=VolcanoTarget] at @s unless block ~ ~ ~ scaffolding unless block ~ ~-1 ~ scaffolding run tag @s add VolcanoAbortTarget
+execute as @e[type=marker,tag=VolcanoTarget] at @s unless block ~ ~ ~ scaffolding unless block ~ ~-1 ~ scaffolding run tag @s add VolcanoAbortTarget
 
-execute as @e[tag=VolcanoTarget,tag=VolcanoAbortTarget] at @s run tp @s ~ ~5 ~
+execute as @e[type=marker,tag=VolcanoTarget,tag=VolcanoAbortTarget] at @s run tp @s ~ ~5 ~
 
 scoreboard players set #RandoWalk global 25
-execute as @e[tag=VolcanoTarget] at @s run function scaffolding_rush:game/volcano/projection/random_walk
+execute as @e[type=marker,tag=VolcanoTarget] at @s run function scaffolding_rush:game/volcano/projection/random_walk
 
-execute at @e[tag=VolcanoTarget,tag=!VolcanoAbortTarget] run particle lava ~ ~0.55 ~ 0.5 0.5 0.5 0 50 force
-execute at @e[tag=VolcanoTarget,tag=!VolcanoAbortTarget] run playsound minecraft:item.bucket.fill_lava master @a[distance=..30] ~ ~ ~ 2 2 1
+execute at @e[type=marker,tag=VolcanoTarget,tag=!VolcanoAbortTarget] run particle lava ~ ~0.55 ~ 0.5 0.5 0.5 0 50 force
+execute at @e[type=marker,tag=VolcanoTarget,tag=!VolcanoAbortTarget] run playsound minecraft:item.bucket.fill_lava master @a[distance=..30] ~ ~ ~ 2 2 1
 #  unless entity @a[tag=InGame,gamemode=adventure,distance=..2]
 
 # Final position rf in miliblock
-execute as @e[tag=VolcanoTarget] at @s run function glib.location:get
-scoreboard players operation #rf_x global = @e[tag=VolcanoTarget] glib.locX
-scoreboard players operation #rf_y global = @e[tag=VolcanoTarget] glib.locY
-scoreboard players operation #rf_z global = @e[tag=VolcanoTarget] glib.locZ
+execute as @e[type=marker,tag=VolcanoTarget] at @s run function glib.location:get
+scoreboard players operation #rf_x global = @e[type=marker,tag=VolcanoTarget] glib.locX
+scoreboard players operation #rf_y global = @e[type=marker,tag=VolcanoTarget] glib.locY
+scoreboard players operation #rf_z global = @e[type=marker,tag=VolcanoTarget] glib.locZ
 scoreboard players operation #rf_x global *= 1000 glib.const
 scoreboard players operation #rf_y global *= 1000 glib.const
 scoreboard players operation #rf_z global *= 1000 glib.const
@@ -65,4 +65,4 @@ scoreboard players operation #scnd_term global /= 2 glib.const
 scoreboard players operation @s glib.vectorY -= #scnd_term global
 
 # Clear
-kill @e[tag=VolcanoTarget]
+kill @e[type=marker,tag=VolcanoTarget]

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/summon.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/game/volcano/summon.mcfunction
@@ -1,15 +1,15 @@
 summon marker 1000 500 1000 {Tags:["Volcano","VolcanoBase","VolcanoBaseNew"]}
 
-spreadplayers 1000 1000 0 50 false @e[tag=VolcanoBaseNew]
+spreadplayers 1000 1000 0 50 false @e[type=marker,tag=VolcanoBaseNew]
 
-execute as @e[tag=VolcanoBaseNew] at @s unless block ~ ~-1 ~ magma_block run tag @s add VolcanoCanceled
-execute as @e[tag=VolcanoBaseNew] at @s if block 1000 ~5 1000 magma_block run tag @s add VolcanoCanceled
-execute as @e[tag=VolcanoBaseNew] at @s if entity @e[type=villager,tag=game_villager,distance=..15] run tag @s add VolcanoCanceled
-execute if entity @s[tag=VolcanoCanceled] run scoreboard players remove VolcanoSummonTimer timer 10
-kill @e[tag=VolcanoCanceled]
+execute as @e[type=marker,tag=VolcanoBaseNew] at @s unless block ~ ~-1 ~ magma_block run tag @s add VolcanoCanceled
+execute as @e[type=marker,tag=VolcanoBaseNew] at @s if block 1000 ~5 1000 magma_block run tag @s add VolcanoCanceled
+execute as @e[type=marker,tag=VolcanoBaseNew] at @s if entity @e[type=villager,tag=game_villager,distance=..15] run tag @s add VolcanoCanceled
+execute if entity @e[type=marker,tag=VolcanoCanceled] run scoreboard players remove VolcanoSummonTimer timer 10
+kill @e[type=marker,tag=VolcanoCanceled]
 
-execute at @e[tag=VolcanoBaseNew] run playsound minecraft:entity.warden.dig master @a ~ ~1000 ~ 2 0.5 1
+execute at @e[type=marker,tag=VolcanoBaseNew] run playsound minecraft:entity.warden.dig master @a ~ ~1000 ~ 2 0.5 1
 
-execute at @e[tag=VolcanoBaseNew] run place template scaffolding_rush:volcano ~-7 ~-5 ~-7
+execute at @e[type=marker,tag=VolcanoBaseNew] run place template scaffolding_rush:volcano ~-7 ~-5 ~-7
 
 tag @e remove VolcanoBaseNew

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/mechanics/fireball/motion.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/mechanics/fireball/motion.mcfunction
@@ -1,16 +1,15 @@
-execute as @e[tag=Fireball] at @s run function glib.move:by_vector
-scoreboard players remove @e[tag=Fireball] glib.vectorY 50
+execute as @e[type=marker,tag=Fireball] at @s run function glib.move:by_vector
+scoreboard players remove @e[type=marker,tag=Fireball] glib.vectorY 50
 
-execute as @e[tag=Fireball] at @s run tp @s ~ ~ ~ ~5 ~
+execute as @e[type=marker,tag=Fireball] at @s run tp @s ~ ~ ~ ~5 ~
 
-execute as @e[tag=Fireball] at @s run particle large_smoke ~ ~1.5 ~ 0.3 0.3 0.3 0 1 force
-execute as @e[tag=Fireball] at @s run particle flame ~ ~1.5 ~ 0.3 0.3 0.3 0.1 1 force
-
-scoreboard players set @e[tag=Fireball,scores={glib.lifetime=0..}] glib.lifetime -200
+execute as @e[type=marker,tag=Fireball] at @s run particle large_smoke ~ ~1.5 ~ 0.1 0.1 0.1 0.1 1 force
+execute as @e[type=marker,tag=Fireball] at @s run particle flame ~ ~1.5 ~ 0.1 0.1 0.1 0.1 3 force
 
 
-execute as @e[tag=Fireball,tag=Impact] at @s run playsound minecraft:entity.generic.explode master @a[distance=..30] ~ ~ ~ 2 1 1
-execute as @e[tag=Fireball,tag=Impact] at @s run particle explosion_emitter ~ ~1.7 ~ 0 0 0 0 1 force
 
-execute as @e[tag=Fireball,tag=Impact] at @s run fill ~-3 ~-3 ~-3 ~3 ~3 ~3 air replace #scaffolding_rush:scaffolding
-kill @e[tag=Fireball,tag=Impact]
+execute as @e[type=marker,tag=Fireball,tag=Impact] at @s run playsound minecraft:entity.generic.explode master @a[distance=..30] ~ ~ ~ 2 1 1
+execute as @e[type=marker,tag=Fireball,tag=Impact] at @s run particle explosion_emitter ~ ~1.7 ~ 0 0 0 0 1 force
+
+execute as @e[type=marker,tag=Fireball,tag=Impact] at @s run fill ~-3 ~-3 ~-3 ~3 ~3 ~3 air replace #scaffolding_rush:scaffolding
+kill @e[type=marker,tag=Fireball,tag=Impact]

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/mechanics/fireball/motion.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/mechanics/fireball/motion.mcfunction
@@ -1,8 +1,6 @@
 execute as @e[type=marker,tag=Fireball] at @s run function glib.move:by_vector
 scoreboard players remove @e[type=marker,tag=Fireball] glib.vectorY 50
 
-execute as @e[type=marker,tag=Fireball] at @s run tp @s ~ ~ ~ ~5 ~
-
 execute as @e[type=marker,tag=Fireball] at @s run particle large_smoke ~ ~1.5 ~ 0.1 0.1 0.1 0.1 1 force
 execute as @e[type=marker,tag=Fireball] at @s run particle flame ~ ~1.5 ~ 0.1 0.1 0.1 0.1 3 force
 

--- a/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/mechanics/fireball/summon.mcfunction
+++ b/datapacks/Scaffolding Rush/data/scaffolding_rush/functions/mechanics/fireball/summon.mcfunction
@@ -1,13 +1,14 @@
-summon armor_stand ~ ~-1.7 ~ {NoGravity:1,Invisible:1,Tags:["Fireball","FireballNew"],ArmorItems:[{},{},{},{id:"minecraft:magma_block",Count:1b}]}
+summon marker ~ ~-1.7 ~ {Tags:["Fireball","FireballNew"]}
 playsound minecraft:entity.ghast.shoot master @a[distance=..30] ~ ~ ~ 2 2 1
 
 function glib.vector:classic/get_from_motion
 
-scoreboard players operation @e[tag=FireballNew] glib.vectorX = @s glib.vectorX
-scoreboard players operation @e[tag=FireballNew] glib.vectorY = @s glib.vectorY
-scoreboard players operation @e[tag=FireballNew] glib.vectorZ = @s glib.vectorZ
-scoreboard players set @e[tag=FireballNew] glib.collision 5
-scoreboard players set @e[tag=FireballNew] glib.precision 100
+scoreboard players operation @e[type=marker,tag=FireballNew] glib.vectorX = @s glib.vectorX
+scoreboard players operation @e[type=marker,tag=FireballNew] glib.vectorY = @s glib.vectorY
+scoreboard players operation @e[type=marker,tag=FireballNew] glib.vectorZ = @s glib.vectorZ
+scoreboard players set @e[type=marker,tag=FireballNew] glib.collision 5
+scoreboard players set @e[type=marker,tag=FireballNew] glib.precision 100
+scoreboard players set @e[type=marker,tag=FireballNew] glib.lifetime -100
 
 tag @e remove FireballNew
 


### PR DESCRIPTION
Cette PR vient ajouter une limite max au nombre de gerbes de lave pouvant apparaitre en simultané, définie à 50. Elle vient également limité à 5 seconde le temps de vie des gerbes de lave et à 10 secondes celle des boule de feu.

De plus, cette PR améliore et optimise grandement la mécanique des gerbes de lave de plusieurs aspects :
- Les gerbes sont maintenant des marker (plus de block de magma sur un armor_stand qui donnait des impression de lag)
- Les particules ont été retravaillées pour permettre de les localiser précisément malgré l'absence de block de magma
- Le système de détection de collision est maintenant actif que lorsqu'un joueur est présent dans les 15 blocs à la ronde lors des phases ascendantes des gerbes de lave, et lorsqu'un joueur est présent à 50 blocs à la ronde lors des phases descendantes.
- Lorsque les collisions sont désactivées, la précision pour le système de gestion du mouvement est réduite de sorte à minimiser le nombre de commandes exécutées